### PR TITLE
NPM Package URL Update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1712,8 +1712,8 @@
       }
     },
     "@symplicity/janus-tokens": {
-      "version": "github:Symplicity/janus-tokens#51b01f95ed876fc0639deddf18416f997320d033",
-      "from": "github:Symplicity/janus-tokens",
+      "version": "git+https://github.com/Symplicity/janus-tokens.git#51b01f95ed876fc0639deddf18416f997320d033",
+      "from": "git+https://github.com/Symplicity/janus-tokens.git",
       "dev": true
     },
     "@szmarczak/http-timer": {
@@ -1726,8 +1726,8 @@
       }
     },
     "@tabler/icons": {
-      "version": "github:Symplicity/tabler-icons#f3f948d283b1e96e7a1b0adfaf5c71d0d2b85a07",
-      "from": "github:Symplicity/tabler-icons"
+      "version": "git+https://github.com/Symplicity/tabler-icons.git#d1dcb91e6d7d639053dc1007bf95094935501eeb",
+      "from": "git+https://github.com/Symplicity/tabler-icons.git"
     },
     "@types/component-emitter": {
       "version": "1.2.11",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "@rollup/plugin-commonjs": "^21.0.0",
     "@rollup/plugin-node-resolve": "^13.0.5",
     "@rollup/plugin-replace": "^3.0.0",
-    "@symplicity/janus-tokens": "github:Symplicity/janus-tokens",
+    "@symplicity/janus-tokens": "https://github.com/Symplicity/janus-tokens",
     "autoprefixer": "^10.3.6",
     "bundlewatch": "^0.3.2",
     "clean-css-cli": "^5.4.1",
@@ -176,6 +176,6 @@
     }
   },
   "dependencies": {
-    "@tabler/icons": "github:Symplicity/tabler-icons"
+    "@tabler/icons": "https://github.com/Symplicity/tabler-icons"
   }
 }


### PR DESCRIPTION
Updating urls for Symplicity packages to use https:// protocol instead of github since git:// protocol is deprecated